### PR TITLE
Added libattr fallback from ENOATTR to ENODATA in fake_id0…

### DIFF
--- a/src/extension/fake_id0/fake_id0.c
+++ b/src/extension/fake_id0/fake_id0.c
@@ -51,6 +51,10 @@
 #include "rootlesscontainers/rootlesscontainers.pb-c.h"
 #define XATTR_USER_ROOTLESSCONTAINERS "user.rootlesscontainers"
 
+#ifndef ENOATTR 
+# define ENOATTR ENODATA
+#endif
+
 // return 0 on success.
 int rootlesscontainers_get_xattr (int fd, const char *path, uid_t *uid, gid_t *gid) {
 	Rootlesscontainers__Resource *msg;


### PR DESCRIPTION
… to support builds on fedora.

Builds on fedora can be run by unprivileged users with plain runc: https://github.com/mgoltzsche/cntnr/blob/a2b00584af785413c8eb8dcc43676c148f47260f/Dockerfile
This change does not affect debian-based builds.

(I think in the same file <attr/xattr.h> could be replaced with <sys/xattr.h> removing the libattr dependency but I wasn't sure if this would also work in every other involved build environment.)

Signed-off-by: Max Goltzsche <max.goltzsche@gmail.com>