### PR TITLE
Use different xattr path such as on opensuse tumbleweed

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -26,6 +26,8 @@ CPPFLAGS += -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -I. -I$(VPATH) -I$(VPATH)/../li
 ifdef PERSISTENT_CHOWN
 	CPPFLAGS += -DPERSISTENT_CHOWN
 	CPPFLAGS += $(shell pkg-config --cflags libprotobuf-c)
+	HAS_ATTR_XATTR := $(shell if [ -f /usr/include/attr/xattr.h ]; then echo -DHAS_ATTR_XATTR; fi)
+	CPPFLAGS += ${HAS_ATTR_XATTR}
 endif
 CFLAGS   += -g -Wall -Wextra -O2
 CFLAGS   += $(shell pkg-config --cflags talloc)

--- a/src/extension/fake_id0/fake_id0.c
+++ b/src/extension/fake_id0/fake_id0.c
@@ -46,7 +46,11 @@
 
 #if defined(PERSISTENT_CHOWN)
 #include <unistd.h>
+#if defined(HAS_ATTR_XATTR)
 #include <attr/xattr.h>
+#else
+#include <sys/xattr.h>
+#endif
 #include "path/path.h"
 #include "rootlesscontainers/rootlesscontainers.pb-c.h"
 #define XATTR_USER_ROOTLESSCONTAINERS "user.rootlesscontainers"


### PR DESCRIPTION
Many distros have `/usr/include/attr/xattr.h` as a symlink to `../sys/xattr.h` but openSUSE Tumbleweed does not have that symlink.  Presumably more distros will be like that in the future, so accept either one.